### PR TITLE
gce: fix startup script

### DIFF
--- a/dockercloud/gce.go
+++ b/dockercloud/gce.go
@@ -42,8 +42,10 @@ var (
 const startup = `#!/bin/bash
 sysctl -w net.ipv4.ip_forward=1
 wget -qO- https://get.docker.io/ | sh
-echo 'DOCKER_OPTS="-H :8000"' >> /etc/default/docker
-service docker restart && echo "docker restarted on port :8000"
+until test -f /var/run/docker.pid; do sleep 1 && echo waiting; done
+grep mtu /etc/default/docker || (echo 'DOCKER_OPTS="-H :8000 -mtu 1460"' >> /etc/default/docker)
+service docker restart
+until echo 'GET /' >/dev/tcp/localhost/8000; do sleep 1 && echo waiting; done
 `
 
 // A Google Compute Engine implementation of the Cloud interface


### PR DESCRIPTION
- wait for `docker.pid` to be created before running `service docker restart`
- don't append mtu option if already in `/etc/default/docker`
- wait for docker port to be opened before exiting startup script
